### PR TITLE
Fix for creating dialog windows without parents.

### DIFF
--- a/glib/glib.go
+++ b/glib/glib.go
@@ -854,3 +854,28 @@ func (v *Value) GetString() (string, error) {
 	}
 	return C.GoString((*C.char)(c)), nil
 }
+
+// alias for glib's special user directories
+type UserDirectory C.GUserDirectory
+
+const (
+	DesktopDirectory     = C.G_USER_DIRECTORY_DESKTOP
+	DocumentsDirectory   = C.G_USER_DIRECTORY_DOCUMENTS
+	DownloadDirectory    = C.G_USER_DIRECTORY_DOWNLOAD
+	MusicDirectory       = C.G_USER_DIRECTORY_MUSIC
+	PicturesDirectory    = C.G_USER_DIRECTORY_PICTURES
+	PublicShareDirectory = C.G_USER_DIRECTORY_PUBLIC_SHARE
+	TemplatesDirectory   = C.G_USER_DIRECTORY_TEMPLATES
+	VideosDirectory      = C.G_USER_DIRECTORY_VIDEOS
+)
+
+const UserNDirectories = 8
+
+// GetUserSpecialDir() is a wrapper around g_get_user_special_dir().
+func GetUserSpecialDir(directory UserDirectory) string {
+	dir := (C.g_get_user_special_dir(C.GUserDirectory(directory)))
+	if dir == nil {
+		return ""
+	}
+	return C.GoString((*C.char)(dir))
+}

--- a/glib/glib.go
+++ b/glib/glib.go
@@ -883,28 +883,3 @@ func (v *Value) GetString() (string, error) {
 	}
 	return C.GoString((*C.char)(c)), nil
 }
-
-// alias for glib's special user directories
-type UserDirectory C.GUserDirectory
-
-const (
-	DesktopDirectory     = C.G_USER_DIRECTORY_DESKTOP
-	DocumentsDirectory   = C.G_USER_DIRECTORY_DOCUMENTS
-	DownloadDirectory    = C.G_USER_DIRECTORY_DOWNLOAD
-	MusicDirectory       = C.G_USER_DIRECTORY_MUSIC
-	PicturesDirectory    = C.G_USER_DIRECTORY_PICTURES
-	PublicShareDirectory = C.G_USER_DIRECTORY_PUBLIC_SHARE
-	TemplatesDirectory   = C.G_USER_DIRECTORY_TEMPLATES
-	VideosDirectory      = C.G_USER_DIRECTORY_VIDEOS
-)
-
-const UserNDirectories = 8
-
-// GetUserSpecialDir() is a wrapper around g_get_user_special_dir().
-func GetUserSpecialDir(directory UserDirectory) string {
-	dir := (C.g_get_user_special_dir(C.GUserDirectory(directory)))
-	if dir == nil {
-		return ""
-	}
-	return C.GoString((*C.char)(dir))
-}

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -2619,7 +2619,11 @@ func MessageDialogNew(parent IWindow, flags DialogFlags, mType MessageType, butt
 	s := fmt.Sprintf(format, a...)
 	cstr := C.CString(s)
 	defer C.free(unsafe.Pointer(cstr))
-	c := C._gtk_message_dialog_new(parent.toWindow(),
+	var w *C.GtkWindow = nil
+	if parent != nil {
+		w = parent.toWindow()
+	}
+	c := C._gtk_message_dialog_new(w,
 		C.GtkDialogFlags(flags), C.GtkMessageType(mType),
 		C.GtkButtonsType(buttons), cstr)
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}


### PR DESCRIPTION
The GTK documentation supports creating a message dialog with no parent ([link](https://developer.gnome.org/gtk3/3.8/GtkMessageDialog.html#gtk-message-dialog-new)), but currently, calling `gtk.MessageDialogNew(nil, ...)` will fail with a segfault. This pull requests adds a check for a nil value before calling `toWindow()` on the parent window parameter.
