### PR TITLE
Handle notify::* signals properly (look them up under the name "notify")

### DIFF
--- a/glib/glib.go.h
+++ b/glib/glib.go.h
@@ -97,8 +97,10 @@ _g_signal_connect(void *obj, gchar *name, int func_n)
 	GSignalQuery    query;
 	guint           sig_id;
 	cbinfo          *cbi;
+	gchar           *signal_name;
 
-	sig_id = g_signal_lookup(name, G_OBJECT_TYPE(obj));
+	signal_name = g_str_has_prefix(name, "notify::") ? "notify" : name;
+	sig_id = g_signal_lookup(signal_name, G_OBJECT_TYPE(obj));
 	g_signal_query(sig_id, &query);
 	cbi = (cbinfo *)malloc(sizeof(cbinfo));
 	cbi->name = g_strdup(name);

--- a/glib/glib_test.go
+++ b/glib/glib_test.go
@@ -1,0 +1,43 @@
+package glib_test
+
+import (
+	"github.com/sqs/gotk3/glib"
+	"github.com/sqs/gotk3/gtk"
+	"runtime"
+	"testing"
+)
+
+func init() {
+	gtk.Init(nil)
+}
+
+// TestConnectNotifySignal ensures that property notification signals (those
+// whose name begins with "notify::") are queried by the name "notify" (with the
+// "::" and the property name omitted). This is because the signal is "notify"
+// and the characters after the "::" are not recognized by the signal system.
+//
+// See
+// https://developer.gnome.org/gobject/stable/gobject-The-Base-Object-Type.html#GObject-notify
+// for background, and
+// https://developer.gnome.org/gobject/stable/gobject-Signals.html#g-signal-new
+// for the specification of valid signal names.
+func TestConnectNotifySignal(t *testing.T) {
+	runtime.LockOSThread()
+
+	// Create any GObject that has defined properties.
+	spacing := 0
+	box, _ := gtk.BoxNew(gtk.ORIENTATION_HORIZONTAL, spacing)
+
+	// Connect to a "notify::" signal to listen on property changes.
+	box.Connect("notify::spacing", func() {
+		gtk.MainQuit()
+	})
+
+	glib.IdleAdd(func() bool {
+		spacing++
+		box.SetSpacing(spacing)
+		return true
+	})
+
+	gtk.Main()
+}


### PR DESCRIPTION
Prior to this PR, `_g_signal_connect` in [glib.go.h](./glib/glib.go.h) looked up `notify::*` signals under their full name. But GObject considers all such signals to be registered under the name `notify`, perhaps because they all have the same signature and it'd be redundant to register them both as signals and as properties. I wasn't able to find this stated in the documentation, but I did find [another project that encountered this issue](https://mail.gnome.org/archives/commits-list/2010-February/msg05474.html), [general background info on signals] https://developer.gnome.org/gobject/stable/gobject-The-Base-Object-Type.html#GObject-notify) and [the specification of valid signal names](https://developer.gnome.org/gobject/stable/gobject-Signals.html#g-signal-new) (which doesn't allow `::`).

Anyway, when `_g_signal_connect` tried to look up a `notify::*` signal using `g_signal_query`, it would fail to find it, and the program would die with a SIGSEGV:

```
$ go test
SIGSEGV: segmentation violation
PC=0x412f34
signal arrived during cgo execution

runtime.cgocall(0x413700, 0x7f6220271a60)
    /usr/local/go/src/pkg/runtime/cgocall.c:149 +0x11b fp=0x7f6220271a48
github.com/sqs/gotk3/gtk._Cfunc_gtk_box_set_spacing(0x7f62040040f0, 0x7f6200000001)
    github.com/sqs/gotk3/gtk/_obj/_cgo_defun.c:214 +0x31 fp=0x7f6220271a60
github.com/sqs/gotk3/gtk.(*Box).SetSpacing(0xc210069018, 0x1)
    /home/sqs/src/github.com/sqs/gotk3/gtk/gtk.go:771 +0x40 fp=0x7f6220271a78
github.com/sqs/gotk3/glib_test.func��002(0x0)
    /home/sqs/src/github.com/sqs/gotk3/glib/glib_test.go:44 +0x3e fp=0x7f6220271a90
runtime.call16(0xc21006e000, 0xc210069030)
    /usr/local/go/src/pkg/runtime/asm_amd64.s:338 +0x32 fp=0x7f6220271aa8
reflect.Value.call(0x4f29e0, 0xc21006e000, 0x130, 0x547970, 0x4, ...)
    /usr/local/go/src/pkg/reflect/value.go:474 +0xe0b fp=0x7f6220271ce8
reflect.Value.Call(0x4f29e0, 0xc21006e000, 0x130, 0x0, 0x0, ...)
    /usr/local/go/src/pkg/reflect/value.go:345 +0x9d fp=0x7f6220271d48
github.com/sqs/gotk3/glib._go_glib_idle_fn(0x7f620400b5c0)
    /home/sqs/src/github.com/sqs/gotk3/glib/glib.go:253 +0xd8 fp=0x7f6220271db8
----- stack segment boundary -----
runtime.cgocallbackg1()
    /usr/local/go/src/pkg/runtime/cgocall.c:296 +0xbf fp=0x7f6220271e78
runtime.cgocallbackg()
    /usr/local/go/src/pkg/runtime/cgocall.c:266 +0x84 fp=0x7f6220271e88
runtime.cgocallback_gofunc(0x4195e3, 0x414800, 0x7f6220271f00)
    /usr/local/go/src/pkg/runtime/asm_amd64.s:711 +0x67 fp=0x7f6220271e98
runtime.asmcgocall(0x414800, 0x7f6220271f00)
    /usr/local/go/src/pkg/runtime/asm_amd64.s:618 +0x2d fp=0x7f6220271ea0
runtime.cgocall(0x414800, 0x7f6220271f00)
    /usr/local/go/src/pkg/runtime/cgocall.c:149 +0x133 fp=0x7f6220271ee8
github.com/sqs/gotk3/gtk._Cfunc_gtk_main(0x44b951)
    github.com/sqs/gotk3/gtk/_obj/_cgo_defun.c:1852 +0x31 fp=0x7f6220271f00
github.com/sqs/gotk3/gtk.Main()
    /home/sqs/src/github.com/sqs/gotk3/gtk/gtk.go:354 +0x1a fp=0x7f6220271f08
github.com/sqs/gotk3/glib_test.TestConnectNotifySignal(0xc210067000)
    /home/sqs/src/github.com/sqs/gotk3/glib/glib_test.go:48 +0x161 fp=0x7f6220271f60
testing.tRunner(0xc210067000, 0x8ac850)
    /usr/local/go/src/pkg/testing/testing.go:389 +0x8b fp=0x7f6220271f90
runtime.goexit()
    /usr/local/go/src/pkg/runtime/proc.c:1396 fp=0x7f6220271f98
created by testing.RunTests
    /usr/local/go/src/pkg/testing/testing.go:469 +0x8b2

goroutine 1 [chan receive]:
testing.RunTests(0x591ba0, 0x8ac850, 0x1, 0x1, 0x1)
    /usr/local/go/src/pkg/testing/testing.go:470 +0x8d5
testing.Main(0x591ba0, 0x8ac850, 0x1, 0x1, 0x8bfec0, ...)
    /usr/local/go/src/pkg/testing/testing.go:401 +0x84
main.main()
    github.com/sqs/gotk3/glib/_test/_testmain.go:47 +0x9c

goroutine 3 [syscall]:
runtime.goexit()
    /usr/local/go/src/pkg/runtime/proc.c:1396

rax     0x7f61154b9010
rbx     0x7f6204013c40
rcx     0x30
rdx     0x349
rdi     0x7f621394f5a0
rsi     0x7f6213951000
rbp     0x0
rsp     0x7f621394f580
r8      0x7f6213951008
r9      0x1dd68cc0
r10     0x22
r11     0x246
r12     0x7f6204013ca0
r13     0x2
r14     0x7f621394f770
r15     0x7f621394f710
rip     0x412f34
rflags  0x10202
cs      0x33
fs      0x0
gs      0x0
exit status 2
FAIL    github.com/sqs/gotk3/glib   0.146s
```

This PR modifies `_g_signal_connect` to check if the signal name begins with `notify::`, and if so, look up the signal as `notify`.

The included test may need to run several times until it fails (on the unpatched source) because the `_g_signal_connect` code works if `query.n_params`, which is uninitialized memory, is 0 or negative (in which case the `for` loop in `_glib_callback` never executes, because `i < cbi->nargs` on the first iteration).

Note: If you check out this branch on _my_ repository (sqs/gotk3), you will need to update the import paths to all point to my repository or else you will get a C symbol redefinition error. But merging it into conformal/gtk3 should work fine.
