### PR TITLE
added basic support of GtkCssProvider

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -1060,11 +1060,6 @@ func (v *CssProvider) Native() *C.GtkCssProvider {
 	return &v.GtkCssProvider
 }
 
-func (v *CssProvider) LoadFromData(cssText string) {
-	cstr := C.CString(cssText)
-	C.gtk_css_provider_load_from_data(v.Native(), (*C.gchar)(cstr), -1, nil)
-}
-
 func NewCssProvider() (*CssProvider, error) {
 	c := C.gtk_css_provider_new()
 	if c == nil {
@@ -1074,7 +1069,18 @@ func NewCssProvider() (*CssProvider, error) {
 	return t, nil
 }
 
-// gtk_style_context_add_provider_for_screen()
+func (v *CssProvider) LoadFromData(cssText string) bool {
+	cstr := C.CString(cssText)
+	return gobool(C.gtk_css_provider_load_from_data(v.Native(), (*C.gchar)(cstr), -1, nil))
+}
+
+func (v *CssProvider) LoadFromPath(path string) bool {
+	cstr := C.CString(path)
+	var err *C.GError = nil
+	return gobool(C.gtk_css_provider_load_from_path(v.Native(), (*C.gchar)(cstr), &err))
+}
+
+// AddToScreen() is wrapper around gtk_style_context_add_provider_for_screen()
 func (v *CssProvider) AddToScreen(screen *gdk.Screen) {
 	p := unsafe.Pointer(v)
 	C.gtk_style_context_add_provider_for_screen(screen.Native(), C.toGtkStyleProvider(p), 0)

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -1049,6 +1049,38 @@ func (v *Clipboard) SetText(text string) {
 }
 
 /*
+ * GtkCssProvider
+ */
+
+type CssProvider struct {
+	GtkCssProvider C.GtkCssProvider
+}
+
+func (v *CssProvider) Native() *C.GtkCssProvider {
+	return &v.GtkCssProvider
+}
+
+func (v *CssProvider) LoadFromData(cssText string) {
+	cstr := C.CString(cssText)
+	C.gtk_css_provider_load_from_data(v.Native(), (*C.gchar)(cstr), -1, nil)
+}
+
+func NewCssProvider() (*CssProvider, error) {
+	c := C.gtk_css_provider_new()
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	t := &CssProvider{*c}
+	return t, nil
+}
+
+// gtk_style_context_add_provider_for_screen()
+func (v *CssProvider) AddToScreen(screen *gdk.Screen) {
+	p := unsafe.Pointer(v)
+	C.gtk_style_context_add_provider_for_screen(screen.Native(), C.toGtkStyleProvider(p), 0)
+}
+
+/*
  * GtkComboBox
  */
 

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -224,6 +224,12 @@ toGtkClipboard(void *p)
 	return (GTK_CLIPBOARD(p));
 }
 
+static GtkStyleProvider *
+toGtkStyleProvider(void *p)
+{
+        return (GTK_STYLE_PROVIDER(p));
+}
+
 static GtkDialog *
 toGtkDialog(void *p)
 {


### PR DESCRIPTION
Simple example of gradient background:

``` go
package main

import (
    "github.com/conformal/gotk3/gtk"
    "github.com/conformal/gotk3/gdk"
    "log"
)

func main() {
    // Initialize GTK without parsing any command line arguments.
    gtk.Init(nil)

    // Create a new toplevel window, set its title, and connect it to the
    // "destroy" signal to exit the GTK main loop when it is destroyed.
    win, err := gtk.WindowNew(gtk.WINDOW_TOPLEVEL)
    if err != nil {
        log.Fatal("Unable to create window:", err)
    }
    win.SetTitle("Simple Example")
    win.Connect("destroy", func() {
        gtk.MainQuit()
    })

    // Create a new label widget to show in the window.
    l, err := gtk.LabelNew("Hello, gotk3!")
    if err != nil {
        log.Fatal("Unable to create label:", err)
    }

    // Add the label to the window.
    win.Add(l)

    // Set the default window size.
    win.SetDefaultSize(800, 600)

    provider, _ := gtk.NewCssProvider()
    display, _ := gdk.DisplayGetDefault()
    screen, _ := display.GetDefaultScreen()

    provider.AddToScreen(screen)
    provider.LoadFromData(" GtkWindow {background: -gtk-gradient (linear,0 0,0 1,color-stop(0, #333),color-stop(0.2, #666))}")

    // Recursively show all widgets contained in this window.
    win.ShowAll()

    // Begin executing the GTK main loop.  This blocks until
    // gtk.MainQuit() is run. 
    gtk.Main()
}
```
