### PR TITLE
gtk.ImageNewFromPixbuf binding and gdk prereq gdk.PixbufNew

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -534,9 +534,10 @@ func (v *Pixbuf) GetPixels() (pixels []byte) {
 	sliceHeader.Len = int(length)
 	sliceHeader.Cap = int(length)
 	// To make sure the slice doesn't outlive the Pixbuf, add a reference
-	obj := &glib.Object{v.GObject}
-	obj.Ref()
-	runtime.SetFinalizer(&pixels, (*glib.Object).Unref)
+	v.Ref()
+	runtime.SetFinalizer(&pixels, func(_ *[]byte) {
+		v.Unref()
+	})
 	return
 }
 

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -24,6 +24,7 @@ import "C"
 import (
 	"errors"
 	"github.com/conformal/gotk3/glib"
+	"reflect"
 	"runtime"
 	"unsafe"
 )
@@ -525,10 +526,18 @@ func (v *Pixbuf) GetBitsPerSample() int {
 // GetPixels is a wrapper around gdk_pixbuf_get_pixels_with_length().
 // A Go slice is used to represent the underlying Pixbuf data array, one
 // byte per channel.
-func (v *Pixbuf) GetPixels() []byte {
+func (v *Pixbuf) GetPixels() (pixels []byte) {
 	var length C.guint
 	c := C.gdk_pixbuf_get_pixels_with_length(v.Native(), &length)
-	return C.GoBytes(unsafe.Pointer(c), (C.int)(length))
+	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&pixels))
+	sliceHeader.Data = uintptr(unsafe.Pointer(c))
+	sliceHeader.Len = int(length)
+	sliceHeader.Cap = int(length)
+	// To make sure the slice doesn't outlive the Pixbuf, add a reference
+	obj := &glib.Object{v.GObject}
+	obj.Ref()
+	runtime.SetFinalizer(pixels, (*glib.Object).Unref)
+	return
 }
 
 // GetWidth is a wrapper around gdk_pixbuf_get_width().
@@ -565,6 +574,21 @@ func (v *Pixbuf) GetOption(key string) (value string, ok bool) {
 		return "", false
 	}
 	return C.GoString((*C.char)(c)), true
+}
+
+// PixbufNew is a wrapper around gdk_pixbuf_new().
+func PixbufNew(colorspace Colorspace, hasAlpha bool, bitsPerSample int, width int, height int) (*Pixbuf, error) {
+	cs := C.GdkColorspace(colorspace)
+	ha := gbool(hasAlpha)
+	c := C.gdk_pixbuf_new(cs, ha, C.int(bitsPerSample), C.int(width), C.int(height))
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	p := &Pixbuf{obj}
+	obj.Ref()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return p, nil
 }
 
 /*

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -536,7 +536,7 @@ func (v *Pixbuf) GetPixels() (pixels []byte) {
 	// To make sure the slice doesn't outlive the Pixbuf, add a reference
 	obj := &glib.Object{v.GObject}
 	obj.Ref()
-	runtime.SetFinalizer(pixels, (*glib.Object).Unref)
+	runtime.SetFinalizer(&pixels, (*glib.Object).Unref)
 	return
 }
 

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3654,11 +3654,18 @@ func ImageNewFromResource(resourcePath string) (*Image, error) {
 	return i, nil
 }
 
-// TODO(jrick) GdkPixbuf
-/*
-func ImageNewFromPixbuf() {
+// ImageNewFromPixbuf() is a wrapper around gtk_image_new_from_pixbuf().
+func ImageNewFromPixbuf(pixbuf *gdk.Pixbuf) (*Image, error) {
+    c := C.gtk_image_new_from_pixbuf((*C.GdkPixbuf)(pixbuf.Native()))
+    if c == nil {
+        return nil, nilPtrErr
+    }
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	i := wrapImage(obj)
+	obj.RefSink()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return i, nil
 }
-*/
 
 // TODO(jrick) GtkIconSet
 /*
@@ -3756,11 +3763,18 @@ func (v *Image) GetStorageType() ImageType {
 	return ImageType(c)
 }
 
-// TODO(jrick) GdkPixbuf
-/*
-func (v *Image) GetPixbuf() {
+// GetPixbuf() is a wrapper around gtk_image_get_pixbuf().
+func (v *Image) GetPixbuf() *gdk.Pixbuf {
+    c := C.gtk_image_get_pixbuf(v.Native())
+	if c == nil {
+		return nil
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	pb := &gdk.Pixbuf{obj}
+	obj.Ref()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return pb
 }
-*/
 
 // TODO(jrick) GtkIconSet
 /*


### PR DESCRIPTION
Tested this with GTK 3.10.  It might be useful to add a wrapper function for the standard library image.Image type, to automatically populate a Pixbuf.
