### PR TITLE
Implemented image.Image interface for gdk.Pixbuf

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -542,6 +542,28 @@ func (v *Pixbuf) At(x, y int) color.Color {
 	return c
 }
 
+// Required to complete the draw.Image interface
+func (v *Pixbuf) Set(x, y int, c color.Color) {
+	alpha := v.GetHasAlpha()
+	stride := v.GetRowstride()
+	pixels := v.GetPixels()
+	offset := 3
+	if alpha {
+		offset = 4
+	}
+	p := y*stride + x*offset
+	if p < len(pixels) {
+		r, g, b, a := c.RGBA()
+		pixels[p] = byte(r / 256)
+		pixels[p+1] = byte(g / 256)
+		pixels[p+2] = byte(b / 256)
+		if alpha {
+			pixels[p+3] = byte(a / 256)
+		}
+	}
+	return
+}
+
 // native returns a pointer to the underlying GdkPixbuf.
 func (v *Pixbuf) native() *C.GdkPixbuf {
 	if v == nil || v.GObject == nil {

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -24,6 +24,8 @@ import "C"
 import (
 	"errors"
 	"github.com/conformal/gotk3/glib"
+	"image"
+	"image/color"
 	"reflect"
 	"runtime"
 	"unsafe"
@@ -502,6 +504,42 @@ func (v *Event) free() {
 // Pixbuf is a representation of GDK's GdkPixbuf.
 type Pixbuf struct {
 	*glib.Object
+}
+
+// Required to implement the image.Image method set
+func (v *Pixbuf) ColorModel() color.Model {
+	return color.RGBAModel
+}
+
+// Required to implement the image.Image method set
+func (v *Pixbuf) Bounds() image.Rectangle {
+	return image.Rect(0, 0, v.GetWidth(), v.GetHeight())
+}
+
+// Required to implement the image.Image method set
+func (v *Pixbuf) At(x, y int) color.Color {
+	var c color.RGBA
+	width := v.GetWidth()
+	height := v.GetHeight()
+	alpha := v.GetHasAlpha()
+	stride := v.GetRowstride()
+	pixels := v.GetPixels()
+	offset := 3
+	if alpha {
+		offset = 4
+	}
+	if x < width && y < height {
+		i := (y * stride) + (x * offset)
+		c.R = pixels[i]
+		c.G = pixels[i+1]
+		c.B = pixels[i+2]
+		if alpha {
+			c.A = pixels[i+3]
+		} else {
+			c.A = 0xff
+		}
+	}
+	return c
 }
 
 // native returns a pointer to the underlying GdkPixbuf.


### PR DESCRIPTION
This might not strictly be a "binding", so maybe things like this should go in a separate file/folder?

The code uses the assumption that there are either 3 or 4 channels, at 8 bits each, because that is all that seems to be supported in GDK at the moment.
