### PR TITLE
Adding a bunch of functions my app needs

### DIFF
--- a/cairo/cairo.go
+++ b/cairo/cairo.go
@@ -291,7 +291,7 @@ const (
 	FORMAT_A8        Format = C.CAIRO_FORMAT_A8
 	FORMAT_A1        Format = C.CAIRO_FORMAT_A1
 	FORMAT_RGB16_565 Format = C.CAIRO_FORMAT_RGB16_565
-	FORMAT_RGB30     Format = C.CAIRO_FORMAT_RGB30
+	//FORMAT_RGB30     Format = C.CAIRO_FORMAT_RGB30  // not in GTK 3.6
 )
 
 func marshalFormat(p uintptr) (interface{}, error) {

--- a/cairo/cairo.go
+++ b/cairo/cairo.go
@@ -42,6 +42,9 @@ func init() {
 		{glib.Type(C.cairo_gobject_operator_get_type()), marshalOperator},
 		{glib.Type(C.cairo_gobject_status_get_type()), marshalStatus},
 		{glib.Type(C.cairo_gobject_surface_type_get_type()), marshalSurfaceType},
+		{glib.Type(C.cairo_gobject_format_get_type()), marshalFormat},
+		{glib.Type(C.cairo_gobject_font_slant_get_type()), marshalFontSlant},
+		{glib.Type(C.cairo_gobject_font_weight_get_type()), marshalFontWeight},
 
 		// Boxed
 		{glib.Type(C.cairo_gobject_context_get_type()), marshalContext},

--- a/cairo/cairo.go
+++ b/cairo/cairo.go
@@ -278,6 +278,24 @@ func marshalSurfaceType(p uintptr) (interface{}, error) {
 	return SurfaceType(c), nil
 }
 
+// Format is a representation of Cairo's cairo_format_t.
+type Format int
+
+const (
+	FORMAT_INVALID   Format = C.CAIRO_FORMAT_INVALID
+	FORMAT_ARGB32    Format = C.CAIRO_FORMAT_ARGB32
+	FORMAT_RGB24     Format = C.CAIRO_FORMAT_RGB24
+	FORMAT_A8        Format = C.CAIRO_FORMAT_A8
+	FORMAT_A1        Format = C.CAIRO_FORMAT_A1
+	FORMAT_RGB16_565 Format = C.CAIRO_FORMAT_RGB16_565
+	FORMAT_RGB30     Format = C.CAIRO_FORMAT_RGB30
+)
+
+func marshalFormat(p uintptr) (interface{}, error) {
+	c := C.g_value_get_enum((*C.GValue)(unsafe.Pointer(p)))
+	return Format(c), nil
+}
+
 /*
  * cairo_t
  */
@@ -624,6 +642,39 @@ func (v *Context) ShowPage() {
 
 // TODO(jrick) GetUserData (depends on UserDataKey)
 
+// Path-creation functions
+// http://cairographics.org/manual/cairo-Paths.html
+
+// Rectangle is a wrapper around cairo_rectangle()
+func (v *Context) Rectangle(x, y, width, height float64) {
+	C.cairo_rectangle(v.native(), C.double(x), C.double(y), C.double(width), C.double(height))
+}
+
+// Arc is a wrapper around cairo_arc()
+func (v *Context) Arc(xc, yc, radius, angle1, angle2 float64) {
+	C.cairo_arc(v.native(), C.double(xc), C.double(yc), C.double(radius), C.double(angle1), C.double(angle2))
+}
+
+// ArcNegative is a wrapper around cairo_arc_negative()
+func (v *Context) ArcNegative(xc, yc, radius, angle1, angle2 float64) {
+	C.cairo_arc_negative(v.native(), C.double(xc), C.double(yc), C.double(radius), C.double(angle1), C.double(angle2))
+}
+
+// MoveTo is a wrapper around cairo_move_to()
+func (v *Context) MoveTo(x, y float64) {
+	C.cairo_move_to(v.native(), C.double(x), C.double(y))
+}
+
+// LineTo is a wrapper around cairo_line_to()
+func (v *Context) LineTo(x, y float64) {
+	C.cairo_line_to(v.native(), C.double(x), C.double(y))
+}
+
+// CurveTo is a wrapper around cairo_curve_to()
+func (v *Context) CurveTo(x1, y1, x2, y2, x3, y3 float64) {
+	C.cairo_curve_to(v.native(), C.double(x1), C.double(y1), C.double(x2), C.double(y2), C.double(x3), C.double(y3))
+}
+
 /*
  * cairo_surface_t
  */
@@ -667,6 +718,20 @@ func NewSurface(s uintptr, needsRef bool) *Surface {
 	}
 	runtime.SetFinalizer(surface, (*Surface).destroy)
 	return surface
+}
+
+// ImageSurfaceCreate is a wrapper around cairo_image_surface_create()
+func ImageSurfaceCreate(format Format, width, height int) *Surface {
+	c := C.cairo_image_surface_create(C.cairo_format_t(format), C.int(width), C.int(height))
+	s := wrapSurface(c)
+	runtime.SetFinalizer(s, (*Surface).destroy)
+	return s
+}
+
+// WriteToPNG is a wrapper around cairo_surface_write_to_png
+// TODO: return value
+func (v *Surface) WriteToPNG(filename string) {
+	C.cairo_surface_write_to_png(v.native(), C.CString(filename))
 }
 
 // CreateSimilar is a wrapper around cairo_surface_create_similar().

--- a/cairo/cairo.go
+++ b/cairo/cairo.go
@@ -296,6 +296,33 @@ func marshalFormat(p uintptr) (interface{}, error) {
 	return Format(c), nil
 }
 
+// FontSlant is a representation of Cairo's cairo_font_slant_t.
+type FontSlant int
+
+const (
+	FONT_SLANT_NORMAL  FontSlant = C.CAIRO_FONT_SLANT_NORMAL
+	FONT_SLANT_ITALIC  FontSlant = C.CAIRO_FONT_SLANT_ITALIC
+	FONT_SLANT_OBLIQUE FontSlant = C.CAIRO_FONT_SLANT_OBLIQUE
+)
+
+func marshalFontSlant(p uintptr) (interface{}, error) {
+	c := C.g_value_get_enum((*C.GValue)(unsafe.Pointer(p)))
+	return FontSlant(c), nil
+}
+
+// FontWeight is a representation of Cairo's cairo_font_weight_t.
+type FontWeight int
+
+const (
+	FONT_WEIGHT_NORMAL FontWeight = C.CAIRO_FONT_WEIGHT_NORMAL
+	FONT_WEIGHT_BOLD   FontWeight = C.CAIRO_FONT_WEIGHT_BOLD
+)
+
+func marshalFontWeight(p uintptr) (interface{}, error) {
+	c := C.g_value_get_enum((*C.GValue)(unsafe.Pointer(p)))
+	return FontWeight(c), nil
+}
+
 /*
  * cairo_t
  */
@@ -673,6 +700,21 @@ func (v *Context) LineTo(x, y float64) {
 // CurveTo is a wrapper around cairo_curve_to()
 func (v *Context) CurveTo(x1, y1, x2, y2, x3, y3 float64) {
 	C.cairo_curve_to(v.native(), C.double(x1), C.double(y1), C.double(x2), C.double(y2), C.double(x3), C.double(y3))
+}
+
+// SelectFontFace is a wrapper around cairo_select_font_face().
+func (v *Context) SelectFontFace(name string, slant FontSlant, weight FontWeight) {
+	C.cairo_select_font_face(v.native(), C.CString(name), C.cairo_font_slant_t(slant), C.cairo_font_weight_t(weight))
+}
+
+// SetFontSize is a wrapper around cairo_set_font_size().
+func (v *Context) SetFontSize(size float64) {
+	C.cairo_set_font_size(v.native(), C.double(size))
+}
+
+// ShowText is a wrapper around cairo_show_text().
+func (v *Context) ShowText(text string) {
+	C.cairo_show_text(v.native(), C.CString(text))
 }
 
 /*

--- a/cairo/examples/paths.go
+++ b/cairo/examples/paths.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"math"
-	"../"
+	"github.com/conformal/gotk3/cairo"
 )
 
 func main() {

--- a/cairo/examples/paths.go
+++ b/cairo/examples/paths.go
@@ -36,5 +36,12 @@ func main() {
 	cr.Arc(128, 128, 64, 0, math.Pi * 2)
 	cr.Stroke()
 
+	// text
+	cr.SetSourceRGB(0.3, 0.8, 0.8)
+	cr.MoveTo(20, 20)
+	cr.SelectFontFace("sans", cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_NORMAL)
+	cr.SetFontSize(16)
+	cr.ShowText("Hello World!")
+
 	surf.WriteToPNG("paths.png")
 }

--- a/cairo/examples/paths.go
+++ b/cairo/examples/paths.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"math"
+	"../"
+)
+
+func main() {
+	surf := cairo.ImageSurfaceCreate(cairo.FORMAT_ARGB32, 256, 256)
+
+	cr := cairo.Create(surf)
+
+	// blank the canvas
+	cr.SetSourceRGB(1, 1, 1)
+	cr.Paint()
+
+	// straight line
+	cr.SetSourceRGB(0.3, 0.2, 0.8)
+	cr.MoveTo(32, 32)
+	cr.LineTo(224, 224)
+	cr.Stroke()
+
+	// curved line, with the inside of the curve filled
+	cr.SetSourceRGB(0.8, 0.2, 0.8)
+	cr.MoveTo(32, 224)
+	cr.CurveTo(64, 64, 192, 192, 224, 32)
+	cr.Fill()
+
+	// square
+	cr.SetSourceRGB(0.75, 0, 0)
+	cr.Rectangle(64, 64, 128, 128)
+	cr.Fill()
+
+	// circle
+	cr.SetSourceRGB(0.3, 0.8, 0.3)
+	cr.Arc(128, 128, 64, 0, math.Pi * 2)
+	cr.Stroke()
+
+	surf.WriteToPNG("paths.png")
+}

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -658,6 +658,21 @@ func PixbufNew(colorspace Colorspace, hasAlpha bool, bitsPerSample, width, heigh
 	return p, nil
 }
 
+// PixbufNewFromFile is a wrapper around gdk_pixbuf_new_from_file().
+// TODO: error handling
+func PixbufNewFromFile(filename string) (*Pixbuf, error) {
+	var err *C.GError
+	c := C.gdk_pixbuf_new_from_file(C.CString(filename), &err)
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	p := &Pixbuf{obj}
+	obj.Ref()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return p, nil
+}
+
 /*
  * GdkScreen
  */

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -531,6 +531,12 @@ func (v *Event) free() {
 	C.gdk_event_free(v.native())
 }
 
+// GetCoords is a wrapper around gdk_event_get_coords().
+func (v *Event) GetCoords(x_win *float64, y_win *float64) bool {
+	ok := C.gdk_event_get_coords(v.native(), (*C.gdouble)(x_win), (*C.gdouble)(y_win))
+	return bool(ok == 1)
+}
+
 /*
  * GdkPixbuf
  */

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -673,6 +673,42 @@ func PixbufNewFromFile(filename string) (*Pixbuf, error) {
 	return p, nil
 }
 
+// PixbufNewFromFileAtScale is a wrapper around gdk_pixbuf_new_from_file_at_scale().
+// TODO: error handling
+func PixbufNewFromFileAtScale(filename string, width, height int, preserve_aspect_ratio bool) (*Pixbuf, error) {
+	var err *C.GError
+	var par C.gboolean
+	if preserve_aspect_ratio {
+		par = C.gboolean(1)
+	} else {
+		par = C.gboolean(0)
+	}
+	c := C.gdk_pixbuf_new_from_file_at_scale(C.CString(filename), C.int(width), C.int(height), par, &err)
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	p := &Pixbuf{obj}
+	obj.Ref()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return p, nil
+}
+
+// PixbufNewFromFileAtSize is a wrapper around gdk_pixbuf_new_from_file_at_size().
+// TODO: error handling
+func PixbufNewFromFileAtSize(filename string, width, height int) (*Pixbuf, error) {
+	var err *C.GError
+	c := C.gdk_pixbuf_new_from_file_at_size(C.CString(filename), C.int(width), C.int(height), &err)
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	p := &Pixbuf{obj}
+	obj.Ref()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return p, nil
+}
+
 /*
  * GdkScreen
  */

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -677,13 +677,7 @@ func PixbufNewFromFile(filename string) (*Pixbuf, error) {
 // TODO: error handling
 func PixbufNewFromFileAtScale(filename string, width, height int, preserve_aspect_ratio bool) (*Pixbuf, error) {
 	var err *C.GError
-	var par C.gboolean
-	if preserve_aspect_ratio {
-		par = C.gboolean(1)
-	} else {
-		par = C.gboolean(0)
-	}
-	c := C.gdk_pixbuf_new_from_file_at_scale(C.CString(filename), C.int(width), C.int(height), par, &err)
+	c := C.gdk_pixbuf_new_from_file_at_scale(C.CString(filename), C.int(width), C.int(height), gbool(preserve_aspect_ratio), &err)
 	if c == nil {
 		return nil, nilPtrErr
 	}

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -34,6 +34,7 @@ func init() {
 		// Enums
 		{glib.Type(C.gdk_colorspace_get_type()), marshalColorspace},
 		{glib.Type(C.gdk_pixbuf_alpha_mode_get_type()), marshalPixbufAlphaMode},
+		{glib.Type(C.gdk_event_type_get_type()), marshalEventMask},
 
 		// Objects/Interfaces
 		{glib.Type(C.gdk_device_get_type()), marshalDevice},
@@ -120,6 +121,41 @@ const (
 	SELECTION_TYPE_WINDOW   Atom = 33
 	SELECTION_TYPE_STRING   Atom = 31
 )
+
+// EventMask is a representation of GDK's GdkEventMask.
+type EventMask int
+
+const (
+	EXPOSURE_MASK            EventMask = C.GDK_EXPOSURE_MASK
+	POINTER_MOTION_MASK      EventMask = C.GDK_POINTER_MOTION_MASK
+	POINTER_MOTION_HINT_MASK EventMask = C.GDK_POINTER_MOTION_HINT_MASK
+	BUTTON_MOTION_MASK       EventMask = C.GDK_BUTTON_MOTION_MASK
+	BUTTON1_MOTION_MASK      EventMask = C.GDK_BUTTON1_MOTION_MASK
+	BUTTON2_MOTION_MASK      EventMask = C.GDK_BUTTON2_MOTION_MASK
+	BUTTON3_MOTION_MASK      EventMask = C.GDK_BUTTON3_MOTION_MASK
+	BUTTON_PRESS_MASK        EventMask = C.GDK_BUTTON_PRESS_MASK
+	BUTTON_RELEASE_MASK      EventMask = C.GDK_BUTTON_RELEASE_MASK
+	KEY_PRESS_MASK           EventMask = C.GDK_KEY_PRESS_MASK
+	KEY_RELEASE_MASK         EventMask = C.GDK_KEY_RELEASE_MASK
+	ENTER_NOTIFY_MASK        EventMask = C.GDK_ENTER_NOTIFY_MASK
+	LEAVE_NOTIFY_MASK        EventMask = C.GDK_LEAVE_NOTIFY_MASK
+	FOCUS_CHANGE_MASK        EventMask = C.GDK_FOCUS_CHANGE_MASK
+	STRUCTURE_MASK           EventMask = C.GDK_STRUCTURE_MASK
+	PROPERTY_CHANGE_MASK     EventMask = C.GDK_PROPERTY_CHANGE_MASK
+	VISIBILITY_NOTIFY_MASK   EventMask = C.GDK_VISIBILITY_NOTIFY_MASK
+	PROXIMITY_IN_MASK        EventMask = C.GDK_PROXIMITY_IN_MASK
+	PROXIMITY_OUT_MASK       EventMask = C.GDK_PROXIMITY_OUT_MASK
+	SUBSTRUCTURE_MASK        EventMask = C.GDK_SUBSTRUCTURE_MASK
+	SCROLL_MASK              EventMask = C.GDK_SCROLL_MASK
+	TOUCH_MASK               EventMask = C.GDK_TOUCH_MASK
+	SMOOTH_SCROLL_MASK       EventMask = C.GDK_SMOOTH_SCROLL_MASK
+	ALL_EVENTS_MASK          EventMask = C.GDK_ALL_EVENTS_MASK
+)
+
+func marshalEventMask(p uintptr) (interface{}, error) {
+	c := C.g_value_get_enum((*C.GValue)(unsafe.Pointer(p)))
+	return EventMask(c), nil
+}
 
 /*
  * GdkAtom

--- a/glib/glib.go
+++ b/glib/glib.go
@@ -104,6 +104,10 @@ const (
 	TYPE_VARIANT   Type = C.G_TYPE_VARIANT
 )
 
+func TypeInit() {
+    C.g_type_init();
+}
+
 // Name is a wrapper around g_type_name().
 func (t Type) Name() string {
 	return C.GoString((*C.char)(C.g_type_name(C.GType(t))))

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -865,7 +865,7 @@ func (v *AboutDialog) SetLicenseType(license License) {
 
 // SetLogo is a wrapper around gtk_about_dialog_set_logo().
 func (v *AboutDialog) SetLogo(logo *gdk.Pixbuf) {
-	logoPtr := (*C.GdkDisplay)(unsafe.Pointer(logo.Native()))
+	logoPtr := (*C.GdkPixbuf)(unsafe.Pointer(logo.Native()))
 	C.gtk_about_dialog_set_logo(v.native(), logoPtr)
 }
 
@@ -8634,7 +8634,7 @@ func (v *Window) SetDefaultGeometry(width, height int) {
 
 // SetIcon is a wrapper around gtk_window_set_icon().
 func (v *Window) SetIcon(icon *gdk.Pixbuf) {
-	iconPtr := (*C.GdkDisplay)(unsafe.Pointer(icon.Native()))
+	iconPtr := (*C.GdkPixbuf)(unsafe.Pointer(icon.Native()))
 	C.gtk_window_set_icon(v.native(), iconPtr)
 }
 

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8019,7 +8019,7 @@ func (v *Widget) GetEvents() int {
 }
 
 // AddEvents is a wrapper around gtk_widget_add_events().
-func (v *Widget) AddEvents(events int) {
+func (v *Widget) AddEvents(events gdk.EventMask) {
 	C.gtk_widget_add_events(v.native(), C.gint(events))
 }
 

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8305,6 +8305,12 @@ func (v *Window) SetDefaultGeometry(width, height int) {
 		C.gint(height))
 }
 
+// SetIcon is a wrapper around gtk_window_set_icon().
+func (v *Window) SetIcon(icon *gdk.Pixbuf) {
+	iconPtr := (*C.GdkDisplay)(unsafe.Pointer(icon.Native()))
+	C.gtk_window_set_icon(v.native(), iconPtr)
+}
+
 // TODO(jrick) GdkGeometry GdkWindowHints.
 /*
 func (v *Window) SetGeometryHints() {

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -140,6 +140,7 @@ func init() {
 		{glib.Type(C.gtk_notebook_get_type()), marshalNotebook},
 		{glib.Type(C.gtk_offscreen_window_get_type()), marshalOffscreenWindow},
 		{glib.Type(C.gtk_orientable_get_type()), marshalOrientable},
+		{glib.Type(C.gtk_paned_get_type()), marshalPaned},
 		{glib.Type(C.gtk_progress_bar_get_type()), marshalProgressBar},
 		{glib.Type(C.gtk_radio_button_get_type()), marshalRadioButton},
 		{glib.Type(C.gtk_radio_menu_item_get_type()), marshalRadioMenuItem},
@@ -5471,6 +5472,67 @@ func (v *Orientable) GetOrientation() Orientation {
 func (v *Orientable) SetOrientation(orientation Orientation) {
 	C.gtk_orientable_set_orientation(v.native(),
 		C.GtkOrientation(orientation))
+}
+
+/*
+ * GtkPaned
+ */
+
+// Paned is a representation of GTK's GtkPaned.
+type Paned struct {
+	Bin
+}
+
+// native returns a pointer to the underlying GtkPaned.
+func (v *Paned) native() *C.GtkPaned {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGtkPaned(p)
+}
+
+func marshalPaned(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	return wrapPaned(obj), nil
+}
+
+func wrapPaned(obj *glib.Object) *Paned {
+	return &Paned{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}}
+}
+
+// PanedNew() is a wrapper around gtk_scrolled_window_new().
+func PanedNew(orientation Orientation) (*Paned, error) {
+	c := C.gtk_paned_new(C.GtkOrientation(orientation))
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	s := wrapPaned(obj)
+	obj.RefSink()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return s, nil
+}
+
+// Add1() is a wrapper around gtk_paned_add1().
+func (v *Paned) Add1(child IWidget) {
+	C.gtk_paned_add1(v.native(), child.toWidget())
+}
+
+// Add2() is a wrapper around gtk_paned_add2().
+func (v *Paned) Add2(child IWidget) {
+	C.gtk_paned_add2(v.native(), child.toWidget())
+}
+
+// Pack1() is a wrapper around gtk_paned_pack1().
+func (v *Paned) Pack1(child IWidget, resize, shrink bool) {
+	C.gtk_paned_pack1(v.native(), child.toWidget(), gbool(resize), gbool(shrink))
+}
+
+// Pack2() is a wrapper around gtk_paned_pack2().
+func (v *Paned) Pack2(child IWidget, resize, shrink bool) {
+	C.gtk_paned_pack2(v.native(), child.toWidget(), gbool(resize), gbool(shrink))
 }
 
 /*

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -985,6 +985,74 @@ func wrapAdjustment(obj *glib.Object) *Adjustment {
 	return &Adjustment{glib.InitiallyUnowned{obj}}
 }
 
+// TODO: AdjustmentNew()
+
+func (v *Adjustment) GetValue() float64 {
+	c := C.gtk_adjustment_get_value(v.native())
+	return float64(c)
+}
+
+func (v *Adjustment) SetValue(value float64) {
+	C.gtk_adjustment_set_value(v.native(), C.gdouble(value))
+}
+
+func (v *Adjustment) GetLower() float64 {
+	c := C.gtk_adjustment_get_lower(v.native())
+	return float64(c)
+}
+
+func (v *Adjustment) SetLower(value float64) {
+	C.gtk_adjustment_set_lower(v.native(), C.gdouble(value))
+}
+
+func (v *Adjustment) GetUpper() float64 {
+	c := C.gtk_adjustment_get_upper(v.native())
+	return float64(c)
+}
+
+func (v *Adjustment) SetUpper(value float64) {
+	C.gtk_adjustment_set_upper(v.native(), C.gdouble(value))
+}
+
+func (v *Adjustment) GetPageSize() float64 {
+	c := C.gtk_adjustment_get_page_size(v.native())
+	return float64(c)
+}
+
+func (v *Adjustment) SetPageSize(value float64) {
+	C.gtk_adjustment_set_page_size(v.native(), C.gdouble(value))
+}
+
+func (v *Adjustment) GetPageIncrement() float64 {
+	c := C.gtk_adjustment_get_page_increment(v.native())
+	return float64(c)
+}
+
+func (v *Adjustment) SetPageIncrement(value float64) {
+	C.gtk_adjustment_set_page_increment(v.native(), C.gdouble(value))
+}
+
+func (v *Adjustment) GetStepIncrement() float64 {
+	c := C.gtk_adjustment_get_step_increment(v.native())
+	return float64(c)
+}
+
+func (v *Adjustment) SetStepIncrement(value float64) {
+	C.gtk_adjustment_set_step_increment(v.native(), C.gdouble(value))
+}
+
+func (v *Adjustment) GetMinimumIncrement() float64 {
+	c := C.gtk_adjustment_get_minimum_increment(v.native())
+	return float64(c)
+}
+
+/*
+void	gtk_adjustment_clamp_page ()
+void	gtk_adjustment_changed ()
+void	gtk_adjustment_value_changed ()
+void	gtk_adjustment_configure ()
+*/
+
 /*
  * GtkAlignment
  */
@@ -6076,6 +6144,32 @@ func (v *ScrolledWindow) SetPolicy(hScrollbarPolicy, vScrollbarPolicy PolicyType
 	C.gtk_scrolled_window_set_policy(v.native(),
 		C.GtkPolicyType(hScrollbarPolicy),
 		C.GtkPolicyType(vScrollbarPolicy))
+}
+
+// GetHAdjustment() is a wrapper around gtk_scrolled_window_get_hadjustment().
+func (v *ScrolledWindow) GetHAdjustment() *Adjustment {
+	c := C.gtk_scrolled_window_get_hadjustment(v.native())
+	if c == nil {
+		return nil
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	a := wrapAdjustment(obj)
+	obj.RefSink()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return a
+}
+
+// GetVAdjustment() is a wrapper around gtk_scrolled_window_get_vadjustment().
+func (v *ScrolledWindow) GetVAdjustment() *Adjustment {
+	c := C.gtk_scrolled_window_get_vadjustment(v.native())
+	if c == nil {
+		return nil
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	a := wrapAdjustment(obj)
+	obj.RefSink()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return a
 }
 
 /*

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -861,6 +861,12 @@ func (v *AboutDialog) SetLicenseType(license License) {
 	C.gtk_about_dialog_set_license_type(v.native(), C.GtkLicense(license))
 }
 
+// SetLogo is a wrapper around gtk_about_dialog_set_logo().
+func (v *AboutDialog) SetLogo(logo *gdk.Pixbuf) {
+	logoPtr := (*C.GdkDisplay)(unsafe.Pointer(logo.Native()))
+	C.gtk_about_dialog_set_logo(v.native(), logoPtr)
+}
+
 // GetLogoIconName is a wrapper around gtk_about_dialog_get_logo_icon_name().
 func (v *AboutDialog) GetLogoIconName() string {
 	c := C.gtk_about_dialog_get_logo_icon_name(v.native())

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3655,6 +3655,11 @@ func (v *FileChooser) GetFilename() string {
 	return s
 }
 
+// AddFilter is a wrapper around gtk_file_chooser_add_filter().
+func (v *FileChooser) AddFilter(filter *FileFilter) {
+	C.gtk_file_chooser_add_filter(v.native(), filter.native())
+}
+
 /*
  * GtkFileChooserButton
  */
@@ -3821,6 +3826,61 @@ func FileChooserWidgetNew(action FileChooserAction) (*FileChooserWidget, error) 
 	obj.RefSink()
 	runtime.SetFinalizer(obj, (*glib.Object).Unref)
 	return f, nil
+}
+
+/*
+ * GtkFileFilter
+ */
+
+// FileChoser is a representation of GTK's GtkFileFilter GInterface.
+type FileFilter struct {
+	*glib.Object
+}
+
+// native returns a pointer to the underlying GObject as a GtkFileFilter.
+func (v *FileFilter) native() *C.GtkFileFilter {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGtkFileFilter(p)
+}
+
+func marshalFileFilter(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	return wrapFileFilter(obj), nil
+}
+
+func wrapFileFilter(obj *glib.Object) *FileFilter {
+	return &FileFilter{obj}
+}
+
+// FileFilterNew is a wrapper around gtk_file_filter_new().
+func FileFilterNew() (*FileFilter, error) {
+	c := C.gtk_file_filter_new()
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	f := wrapFileFilter(obj)
+	obj.RefSink()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return f, nil
+}
+
+// SetName is a wrapper around gtk_file_filter_set_name().
+func (v *FileFilter) SetName(name string) {
+	cstr := C.CString(name)
+	defer C.free(unsafe.Pointer(cstr))
+	C.gtk_file_filter_set_name(v.native(), (*C.gchar)(cstr))
+}
+
+// AddPattern is a wrapper around gtk_file_filter_add_pattern().
+func (v *FileFilter) AddPattern(pattern string) {
+	cstr := C.CString(pattern)
+	defer C.free(unsafe.Pointer(cstr))
+	C.gtk_file_filter_add_pattern(v.native(), (*C.gchar)(cstr))
 }
 
 /*

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7740,6 +7740,11 @@ func (v *Widget) Hide() {
 	C.gtk_widget_hide(v.native())
 }
 
+// QueueDraw is a wrapper around gtk_widget_queue_draw().
+func (v *Widget) QueueDraw() {
+	C.gtk_widget_queue_draw(v.native())
+}
+
 // GetCanFocus is a wrapper around gtk_widget_get_can_focus().
 func (v *Widget) GetCanFocus() bool {
 	c := C.gtk_widget_get_can_focus(v.native())

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -6187,6 +6187,11 @@ func (v *SpinButton) GetValue() float64 {
 	return float64(c)
 }
 
+// SetRange() is a wrapper around gtk_spin_button_set_range().
+func (v *SpinButton) SetRange(min, max float64) {
+	C.gtk_spin_button_set_range(v.native(), C.gdouble(min), C.gdouble(max))
+}
+
 /*
  * GtkSpinner
  */

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7827,6 +7827,18 @@ func (v *Widget) GetNoShowAll() bool {
 	return gobool(c)
 }
 
+// GetAllocatedWidth is a wrapper around gtk_widget_get_allocated_width().
+func (v *Widget) GetAllocatedWidth() int {
+	c := C.gtk_widget_get_allocated_width(v.native())
+	return int(c)
+}
+
+// GetAllocatedHeight is a wrapper around gtk_widget_get_allocated_width().
+func (v *Widget) GetAllocatedHeight() int {
+	c := C.gtk_widget_get_allocated_height(v.native())
+	return int(c)
+}
+
 // Map is a wrapper around gtk_widget_map().
 func (v *Widget) Map() {
 	C.gtk_widget_map(v.native())

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -5535,6 +5535,11 @@ func (v *Paned) Pack2(child IWidget, resize, shrink bool) {
 	C.gtk_paned_pack2(v.native(), child.toWidget(), gbool(resize), gbool(shrink))
 }
 
+// SetPosition() is a wrapper around gtk_paned_set_position().
+func (v *Paned) SetPosition(position int) {
+	C.gtk_paned_set_position(v.native(), C.gint(position))
+}
+
 /*
  * GtkProgressBar
  */

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -124,6 +124,7 @@ func init() {
 		{glib.Type(C.gtk_event_box_get_type()), marshalEventBox},
 		{glib.Type(C.gtk_file_chooser_get_type()), marshalFileChooser},
 		{glib.Type(C.gtk_file_chooser_button_get_type()), marshalFileChooserButton},
+		{glib.Type(C.gtk_file_chooser_dialog_get_type()), marshalFileChooserDialog},
 		{glib.Type(C.gtk_file_chooser_widget_get_type()), marshalFileChooserWidget},
 		{glib.Type(C.gtk_frame_get_type()), marshalFrame},
 		{glib.Type(C.gtk_grid_get_type()), marshalGrid},
@@ -3632,6 +3633,81 @@ func FileChooserButtonNew(title string, action FileChooserAction) (*FileChooserB
 	obj.RefSink()
 	runtime.SetFinalizer(obj, (*glib.Object).Unref)
 	return f, nil
+}
+
+/*
+ * GtkFileChooserDialog
+ */
+
+// FileChooserDialog is a representation of GTK's GtkFileChooserDialog.
+type FileChooserDialog struct {
+	Dialog
+
+	// Interfaces
+	FileChooser
+}
+
+// native returns a pointer to the underlying GtkFileChooserDialog.
+func (v *FileChooserDialog) native() *C.GtkFileChooserDialog {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGtkFileChooserDialog(p)
+}
+
+func marshalFileChooserDialog(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	return wrapFileChooserDialog(obj), nil
+}
+
+func wrapFileChooserDialog(obj *glib.Object) *FileChooserDialog {
+	fc := wrapFileChooser(obj)
+	return &FileChooserDialog{Dialog{Window{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}}}, *fc}
+}
+
+// FileChooserDialogNew is a wrapper around gtk_file_chooser_dialog_new().
+func FileChooserDialogNew1(
+	title string,
+	parent *Window,
+	action FileChooserAction,
+	first_button_text string,
+	first_button_id ResponseType) (*FileChooserDialog, error) {
+	c := C.gtk_file_chooser_dialog_new_1(
+		(*C.gchar)(C.CString(title)), parent.native(), C.GtkFileChooserAction(action),
+		(*C.gchar)(C.CString(first_button_text)), C.int(first_button_id))
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	a := wrapFileChooserDialog(obj)
+	obj.RefSink()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return a, nil
+}
+
+// FileChooserDialogNew is a wrapper around gtk_file_chooser_dialog_new().
+func FileChooserDialogNew2(
+	title string,
+	parent *Window,
+	action FileChooserAction,
+	first_button_text string,
+	first_button_id ResponseType,
+	second_button_text string,
+	second_button_id ResponseType) (*FileChooserDialog, error) {
+	c := C.gtk_file_chooser_dialog_new_2(
+		(*C.gchar)(C.CString(title)), parent.native(), C.GtkFileChooserAction(action),
+		(*C.gchar)(C.CString(first_button_text)), C.int(first_button_id),
+		(*C.gchar)(C.CString(second_button_text)), C.int(second_button_id))
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	a := wrapFileChooserDialog(obj)
+	obj.RefSink()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return a, nil
 }
 
 /*

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7690,6 +7690,19 @@ func (v *TreePath) String() string {
 	return C.GoString((*C.char)(c))
 }
 
+// TreePathNewFromString is a wrapper around gtk_tree_path_new_from_string().
+func TreePathNewFromString(path string) (*TreePath, error) {
+	cstr := C.CString(path)
+	defer C.free(unsafe.Pointer(cstr))
+	c := C.gtk_tree_path_new_from_string((*C.gchar)(cstr))
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	t := &TreePath{c}
+	runtime.SetFinalizer(t, (*TreePath).free)
+	return t, nil
+}
+
 /*
  * GtkTreeSelection
  */
@@ -7730,6 +7743,11 @@ func (v *TreeSelection) GetSelected(model *ITreeModel, iter *TreeIter) bool {
 	c := C.gtk_tree_selection_get_selected(v.native(),
 		pcmodel, iter.native())
 	return gobool(c)
+}
+
+// SelectPath() is a wrapper around gtk_tree_selection_select_path().
+func (v *TreeSelection) SelectPath(path *TreePath) {
+	C.gtk_tree_selection_select_path(v.native(), path.native())
 }
 
 /*

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -80,6 +80,12 @@ toGtkContainer(void *p)
 	return (GTK_CONTAINER(p));
 }
 
+static GtkPaned *
+toGtkPaned(void *p)
+{
+	return (GTK_PANED(p));
+}
+
 static GtkProgressBar *
 toGtkProgressBar(void *p)
 {

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -392,6 +392,12 @@ toGtkFileChooserButton(void *p)
 	return (GTK_FILE_CHOOSER_BUTTON(p));
 }
 
+static GtkFileChooserDialog *
+toGtkFileChooserDialog(void *p)
+{
+	return (GTK_FILE_CHOOSER_DIALOG(p));
+}
+
 static GtkFileChooserWidget *
 toGtkFileChooserWidget(void *p)
 {
@@ -519,4 +525,32 @@ static const gchar *
 object_get_class_name(GObject *object)
 {
 	return G_OBJECT_CLASS_NAME(G_OBJECT_GET_CLASS(object));
+}
+
+GtkWidget *
+gtk_file_chooser_dialog_new_1(
+	const gchar *title,
+	GtkWindow *parent,
+	GtkFileChooserAction action,
+	const gchar *first_button_text, int first_button_id
+) {
+	return gtk_file_chooser_dialog_new(
+		title, parent, action,
+		first_button_text, first_button_id,
+		NULL);
+}
+
+GtkWidget *
+gtk_file_chooser_dialog_new_2(
+	const gchar *title,
+	GtkWindow *parent,
+	GtkFileChooserAction action,
+	const gchar *first_button_text, int first_button_id,
+	const gchar *second_button_text, int second_button_id
+) {
+	return gtk_file_chooser_dialog_new(
+		title, parent, action,
+		first_button_text, first_button_id,
+		second_button_text, second_button_id,
+		NULL);
 }

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -404,6 +404,12 @@ toGtkFileChooserWidget(void *p)
 	return (GTK_FILE_CHOOSER_WIDGET(p));
 }
 
+static GtkFileFilter *
+toGtkFileFilter(void *p)
+{
+	return (GTK_FILE_FILTER(p));
+}
+
 static GtkMenuButton *
 toGtkMenuButton(void *p)
 {


### PR DESCRIPTION
Several cairo functions to create an image, draw on it, and save it to a file (plus example of doing that)

Some GTK odds & ends, in particular enough to have a GtkDrawingArea which responds to mouse events

I haven't done the full APIs, just what I've needed so far, and I will probably be needing more (and thus adding more) shortly; sending a pull request now so that you can tell me if I'm doing anything stupid before I do too much work :)

Even though it's incomplete, it would be nice to merge what's there as my GTK patches require the GDK patches, and having them upstream is cleaner than rewriting all the import statements.
