### PR TITLE
Implemented Gtk{Socket,Plug} in gtk/gtkx

### DIFF
--- a/gtk/gtkx/examples/selfplug/selfplug.go
+++ b/gtk/gtkx/examples/selfplug/selfplug.go
@@ -18,7 +18,7 @@ package main
 import (
 	"fmt"
 	"github.com/conformal/gotk3/gtk"
-	"github.com/runjak/gotk3/gtk/gtkx"
+	"github.com/conformal/gotk3/gtk/gtkx"
 	"log"
 )
 

--- a/gtk/gtkx/examples/selfplug/selfplug.go
+++ b/gtk/gtkx/examples/selfplug/selfplug.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2014 Jakob Runge <sicarius@g4t3.de>
+//
+// This file originated from: http://opensource.conformal.com/
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+package main
+
+import (
+	"fmt"
+	"github.com/conformal/gotk3/gtk"
+	"github.com/runjak/gotk3/gtk/gtkx"
+	"log"
+)
+
+func main() {
+	// Initialize GTK without parsing any command line arguments.
+	gtk.Init(nil)
+
+	// Create a new toplevel window, set its title, and connect it to the
+	// "destroy" signal to exit the GTK main loop when it is destroyed.
+	win, err := gtk.WindowNew(gtk.WINDOW_TOPLEVEL)
+	if err != nil {
+		log.Fatal("Unable to create window:", err)
+	}
+	win.SetTitle("Simple Example")
+	win.Connect("destroy", func() {
+		gtk.MainQuit()
+	})
+
+	// Create a new socket:
+	s, err := gtkx.SocketNew()
+	if err != nil {
+		log.Fatal("Unable to create socket:", err)
+	}
+
+	//Adding the socket to the window:
+	win.Add(s)
+
+	// Getting the socketId:
+	sId := s.GetId()
+	fmt.Printf("Our socket: %v\n", sId)
+
+	//Building a Plug for our Socket:
+	p, err := gtkx.PlugNew(sId)
+	if err != nil {
+		log.Fatal("Unable to create plug:", err)
+	}
+
+	//Building a Button for our Plug:
+	b, err := gtk.ButtonNewWithLabel("Click me .)")
+	if err != nil {
+		log.Fatal("Unable to create button:", err)
+	}
+
+	//Click events for the Button:
+	b.Connect("clicked", func() {
+		fmt.Printf("Yeah, such clicks!\n")
+	})
+
+	//Adding the Button to the Plug:
+	p.Add(b)
+	//Displaying the Plug:
+	p.ShowAll()
+
+	// Set the default window size.
+	win.SetDefaultSize(800, 600)
+
+	// Recursively show all widgets contained in this window.
+	win.ShowAll()
+
+	// Begin executing the GTK main loop.  This blocks until
+	// gtk.MainQuit() is run.
+	gtk.Main()
+}

--- a/gtk/gtkx/examples/xterm/xterm.go
+++ b/gtk/gtkx/examples/xterm/xterm.go
@@ -18,7 +18,7 @@ package main
 import (
 	"fmt"
 	"github.com/conformal/gotk3/gtk"
-	"github.com/runjak/gotk3/gtk/gtkx"
+	"github.com/conformal/gotk3/gtk/gtkx"
 	"log"
 	"os"
 	"os/exec"

--- a/gtk/gtkx/examples/xterm/xterm.go
+++ b/gtk/gtkx/examples/xterm/xterm.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2014 Jakob Runge <sicarius@g4t3.de>
+//
+// This file originated from: http://opensource.conformal.com/
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+package main
+
+import (
+	"fmt"
+	"github.com/conformal/gotk3/gtk"
+	"github.com/runjak/gotk3/gtk/gtkx"
+	"log"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	/*
+	   We set an environment variable so that we don't get bothered by xterm accessibility warnings
+	   like "** (xterm:16917): WARNING **: Couldn't connect to accessibility bus: Failed to connect to socket /tmp/dbus-QznzMfGEXB: Connection refused"
+	   See http://debbugs.gnu.org/cgi/bugreport.cgi?bug=15154
+	*/
+	os.Setenv("NO_AT_BRIDGE", "1")
+
+	// Initialize GTK without parsing any command line arguments.
+	gtk.Init(nil)
+
+	// Create a new toplevel window, set its title, and connect it to the
+	// "destroy" signal to exit the GTK main loop when it is destroyed.
+	win, err := gtk.WindowNew(gtk.WINDOW_TOPLEVEL)
+	if err != nil {
+		log.Fatal("Unable to create window:", err)
+	}
+	win.SetTitle("Simple Example")
+	win.Connect("destroy", func() {
+		gtk.MainQuit()
+	})
+
+	// Create a new socket:
+	s, err := gtkx.SocketNew()
+	if err != nil {
+		log.Fatal("Unable to create socket:", err)
+	}
+
+	//Adding the socket to the window:
+	win.Add(s)
+
+	// Getting the socketId:
+	sId := s.GetId()
+	fmt.Printf("Our socket: %v\n", sId)
+
+	// Embedding something in the socket:
+	xterm := exec.Command("xterm", "-into", gtkx.WindowIdToString(sId))
+
+	go func() {
+		xterm.Run()
+	}()
+
+	// Set the default window size.
+	win.SetDefaultSize(800, 600)
+
+	// Recursively show all widgets contained in this window.
+	win.ShowAll()
+
+	// Begin executing the GTK main loop.  This blocks until
+	// gtk.MainQuit() is run.
+	gtk.Main()
+}

--- a/gtk/gtkx/gtkx.go
+++ b/gtk/gtkx/gtkx.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2014 Jakob Runge <sicarius@g4t3.de>
+//
+// This file originated from: http://opensource.conformal.com/
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+package gtkx
+
+// #cgo pkg-config: gtk+-3.0
+// #include <gtk/gtk.h>
+// #include <gtk/gtkx.h>
+// #include "gtkx.go.h"
+import "C"
+import (
+	"errors"
+	"github.com/conformal/gotk3/gdk"
+	"github.com/conformal/gotk3/glib"
+	"github.com/conformal/gotk3/gtk"
+	"runtime"
+	"strconv"
+	"unsafe"
+)
+
+// We need the same nilPtrErr as ../gtk.go:
+var nilPtrErr = errors.New("cgo returned unexpected nil pointer")
+
+/*
+  This package deals with Sockets and Plugs, which wrap the concept of GtkSocket and GtkPlug as described in [1,2].
+  To deal with both, it is necessary to identify them via their C.Window,
+  that acts as an id and motivates our WindowId type.
+  [1]: https://developer.gnome.org/gtk3/stable/GtkSocket.html
+  [2]: https://developer.gnome.org/gtk3/stable/GtkPlug.html
+*/
+type (
+	// Socket is a representation of GTK's GtkSocket.
+	Socket struct {
+		gtk.Container
+	}
+
+	// Plug is a representation of GTK's GtkPlug.
+	Plug struct {
+		gtk.Window
+	}
+
+	/*
+	   The windowId that gtk uses, which is accessible as C.Window is a word32.
+	   We handle this by using a typealias.
+	*/
+	WindowId uint32
+)
+
+// Native returns a pointer to the underlying GtkSocket.
+func (v *Socket) Native() *C.GtkSocket {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGtkSocket(p)
+}
+
+func wrapSocket(obj *glib.Object) *Socket {
+	return &Socket{gtk.Container{gtk.Widget{glib.InitiallyUnowned{obj}}}}
+}
+
+// SocketNew is a wrapper around gtk_socket_new().
+func SocketNew() (*Socket, error) {
+	c := C.gtk_socket_new()
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	s := wrapSocket(obj)
+	obj.RefSink()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return s, nil
+}
+
+// AddId is a wrapper around gtk_socket_add_id().
+func (v *Socket) AddId(w WindowId) {
+	C.gtk_socket_add_id(v.Native(), C.Window(w))
+}
+
+// GetId is a wrapper around gtk_socket_get_id().
+func (v *Socket) GetId() WindowId {
+	id := C.gtk_socket_get_id(v.Native())
+	return WindowId(id)
+}
+
+// GetPlugWindow is a wrapper around gtk_socket_get_plug_window().
+func (v *Socket) GetPlugWindow() (*gdk.Window, error) {
+	c := C.gtk_socket_get_plug_window(v.Native())
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	w := &gdk.Window{obj}
+	w.Ref()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return w, nil
+}
+
+func (v *Plug) Native() *C.GtkPlug {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGtkPlug(p)
+}
+
+func wrapPlug(obj *glib.Object) *Plug {
+	return &Plug{gtk.Window{gtk.Bin{gtk.Container{gtk.Widget{glib.InitiallyUnowned{obj}}}}}}
+}
+
+// PlugNew is a wrapper around gtk_plug_new().
+func PlugNew(socketId WindowId) (*Plug, error) {
+	c := C.gtk_plug_new(C.Window(socketId))
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	p := wrapPlug(obj)
+	obj.RefSink()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return p, nil
+}
+
+// GetId is a wrapper around gtk_plug_get_id().
+func (v *Plug) GetId() WindowId {
+	id := C.gtk_plug_get_id(v.Native())
+	return WindowId(id)
+}
+
+// GetEmbedded is a wrapper around gtk_plug_get_embedded().
+func (v *Plug) GetEmbedded() bool {
+	c := C.gtk_plug_get_embedded(v.Native())
+	//Sadly we don't have gobool() outside gtk.go:
+	if c != 0 {
+		return true
+	}
+	return false
+}
+
+// GetSocketWindow is a wrapper around gtk_plug_get_socket_window().
+func (v *Plug) GetSocketWindow() (*gdk.Window, error) {
+	c := C.gtk_plug_get_socket_window(v.Native())
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	w := &gdk.Window{obj}
+	w.Ref()
+	runtime.SetFinalizer(obj, (*glib.Object).Unref)
+	return w, nil
+}
+
+func WindowIdToString(w WindowId) string {
+	u := uint32(w)
+	return strconv.FormatUint(uint64(u), 10)
+}
+
+func StringToWindowId(s string) (WindowId, error) {
+	u, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return WindowId(u), nil
+}

--- a/gtk/gtkx/gtkx.go.h
+++ b/gtk/gtkx/gtkx.go.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2014 Jakob Runge <sicarius@g4t3.de>
+//
+// This file originated from: http://opensource.conformal.com/
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static GtkSocket *
+toGtkSocket(void *p)
+{
+  return (GTK_SOCKET(p));
+}
+
+static GtkPlug *
+toGtkPlug(void *p)
+{
+  return (GTK_PLUG(p));
+}


### PR DESCRIPTION
- In C GtkSocket and GtkPlug are used with '#include <gtk/gtkx.h>',
  so I figured it would make sense for them to have a similar module in go.
- There are two examples, selfplug and xterm,
  which demonstrate the Socket/Plug mechanism.
- The selfplug example is just a stack of window->socket->plug->button,
  to see that it's possible to have the Socket and the Plug both from the same program.
- The xterm example executes xterm behind the scenes,
  using the -into parameter to embed it into a Socket.
  Sadly in my test setup xterm wouldn't react to input.
