### PR TITLE
Wrapper for gtk_tree_selection_get_selected_rows

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7486,7 +7486,7 @@ func (v *TreeSelection) GetSelected(model *ITreeModel, iter *TreeIter) bool {
 }
 
 // GetSelectedRows() is a wrapper around gtk_tree_selection_get_selected_rows().
-func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *TreePath {
+func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *glib.List {
 	var pcmodel **C.GtkTreeModel
 	if model != nil {
 		cmodel := (*model).toTreeModel()
@@ -7501,7 +7501,7 @@ func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *TreePath {
 		C.g_list_free_full((*C.GList)(unsafe.Pointer(glist)),
 			(C.GDestroyNotify)(C.gtk_tree_path_free))
 	})
-	return (*TreePath)(unsafe.Pointer(glist))
+	return (*glib.List)(unsafe.Pointer(glist))
 }
 
 /*

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7485,6 +7485,21 @@ func (v *TreeSelection) GetSelected(model *ITreeModel, iter *TreeIter) bool {
 	return gobool(c)
 }
 
+// GetSelectedRows() is a wrapper around gtk_tree_selection_get_selected_rows().
+func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *glib.List {
+	var pcmodel **C.GtkTreeModel
+	if model != nil {
+		cmodel := (*model).toTreeModel()
+		pcmodel = &cmodel
+	} else {
+		pcmodel = nil
+	}
+	glist := (*C.GList)(unsafe.Pointer(v))
+	glist = C.gtk_tree_selection_get_selected_rows(v.native(),
+		pcmodel)
+	return (*glib.List)(unsafe.Pointer(glist))
+}
+
 /*
  * GtkTreeView
  */

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7420,6 +7420,14 @@ type TreePath struct {
 	GtkTreePath *C.GtkTreePath
 }
 
+// Return a TreePath from the GList
+func TreePathFromList(list *glib.List) *TreePath {
+	if list == nil {
+		return nil
+	}
+	return &TreePath{(*C.GtkTreePath)(unsafe.Pointer(list.Data))}
+}
+
 // native returns a pointer to the underlying GtkTreePath.
 func (v *TreePath) native() *C.GtkTreePath {
 	if v == nil {

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7497,6 +7497,7 @@ func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *glib.List {
 	glist := (*C.GList)(unsafe.Pointer(v))
 	glist = C.gtk_tree_selection_get_selected_rows(v.native(),
 		pcmodel)
+	runtime.SetFinalizer(glist, C.gtk_tree_path_free)
 	return (*glib.List)(unsafe.Pointer(glist))
 }
 

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -2513,7 +2513,7 @@ func (v *Container) PropagateDraw(child IWidget, cr *cairo.Context) {
 
 // GetFocusChain is a wrapper around gtk_container_get_focus_chain().
 func (v *Container) GetFocusChain() ([]*Widget, bool) {
-	var cwlist *C.struct__GList
+	var cwlist *C.GList
 	c := C.gtk_container_get_focus_chain(v.native(), &cwlist)
 
 	var widgets []*Widget

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7433,6 +7433,12 @@ func marshalTreePath(p uintptr) (interface{}, error) {
 	return &TreePath{(*C.GtkTreePath)(unsafe.Pointer(c))}, nil
 }
 
+// Returns TreePath from an uintptr. Example GList
+func TreePathFromUintptr(p uintptr) (interface{}, error) {
+	c := C.g_value_get_boxed((*C.GValue)(unsafe.Pointer(p)))
+	return &TreePath{(*C.GtkTreePath)(unsafe.Pointer(c))}, nil
+}
+
 func (v *TreePath) free() {
 	C.gtk_tree_path_free(v.native())
 }

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7502,11 +7502,10 @@ func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *glib.List {
 	} else {
 		pcmodel = nil
 	}
-	glist := (*C.GList)(unsafe.Pointer(v))
-	glist = C.gtk_tree_selection_get_selected_rows(v.native(),
+	glist := C.gtk_tree_selection_get_selected_rows(v.native(),
 		pcmodel)
 	runtime.SetFinalizer(glist, func() {
-		C.g_list_free_full((*C.GList)(unsafe.Pointer(glist)),
+		C.g_list_free_full(glist,
 			(C.GDestroyNotify)(C.gtk_tree_path_free))
 	})
 	return (*glib.List)(unsafe.Pointer(glist))

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7497,7 +7497,10 @@ func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *glib.List {
 	glist := (*C.GList)(unsafe.Pointer(v))
 	glist = C.gtk_tree_selection_get_selected_rows(v.native(),
 		pcmodel)
-	runtime.SetFinalizer(glist, C.gtk_tree_path_free)
+	runtime.SetFinalizer(glist, func() {
+		C.g_list_free_full((*C.GList)(unsafe.Pointer(glist)),
+			(C.GDestroyNotify)(C.gtk_tree_path_free))
+	})
 	return (*glib.List)(unsafe.Pointer(glist))
 }
 

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7433,12 +7433,6 @@ func marshalTreePath(p uintptr) (interface{}, error) {
 	return &TreePath{(*C.GtkTreePath)(unsafe.Pointer(c))}, nil
 }
 
-// Returns TreePath from an uintptr. Example GList
-func TreePathFromUintptr(p uintptr) (interface{}, error) {
-	c := C.g_value_get_boxed((*C.GValue)(unsafe.Pointer(p)))
-	return &TreePath{(*C.GtkTreePath)(unsafe.Pointer(c))}, nil
-}
-
 func (v *TreePath) free() {
 	C.gtk_tree_path_free(v.native())
 }

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7486,7 +7486,7 @@ func (v *TreeSelection) GetSelected(model *ITreeModel, iter *TreeIter) bool {
 }
 
 // GetSelectedRows() is a wrapper around gtk_tree_selection_get_selected_rows().
-func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *glib.List {
+func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *TreePath {
 	var pcmodel **C.GtkTreeModel
 	if model != nil {
 		cmodel := (*model).toTreeModel()
@@ -7501,7 +7501,7 @@ func (v *TreeSelection) GetSelectedRows(model *ITreeModel) *glib.List {
 		C.g_list_free_full((*C.GList)(unsafe.Pointer(glist)),
 			(C.GDestroyNotify)(C.gtk_tree_path_free))
 	})
-	return (*glib.List)(unsafe.Pointer(glist))
+	return (*TreePath)(unsafe.Pointer(glist))
 }
 
 /*


### PR DESCRIPTION
Added wrapper for gtk_tree_selection_get_selected_rows couldn't cast the returning GList to a gtk.TreePath. Maybe someone can give me some help.
