### PR TITLE
Support for char array type conversion and assorted about dialogue functions

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -880,6 +880,19 @@ func (v *AboutDialog) SetArtists(artists []string) {
 	C.gtk_about_dialog_set_artists(v.native(), (**C.gchar)(p))
 }
 
+// GetDocumenters is a wrapper around gtk_about_dialog_get_documenters().
+func (v *AboutDialog) GetDocumenters() []string {
+	p := C.gtk_about_dialog_get_documenters(v.native())
+	return gogchars(p)
+}
+
+// SetDocumenters is a wrapper around gtk_about_dialog_set_documenters().
+func (v *AboutDialog) SetArtists(documenters []string) {
+	p := cstrings(documenters)
+	defer C.free(p)
+	C.gtk_about_dialog_set_documenters(v.native(), (**C.gchar)(p))
+}
+
 // GetComments is a wrapper around gtk_about_dialog_get_comments().
 func (v *AboutDialog) GetComments() string {
 	c := C.gtk_about_dialog_get_comments(v.native())

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -854,6 +854,19 @@ func AboutDialogNew() (*AboutDialog, error) {
 	return a, nil
 }
 
+// GetAuthors is a wrapper around gtk_about_dialog_get_authors().
+func (v *AboutDialog) GetAuthors() []string {
+	p := C.gtk_about_dialog_get_authors(v.native())
+	return gogchars(p)
+}
+
+// SetAuthors is a wrapper around gtk_about_dialog_set_authors().
+func (v *AboutDialog) SetAuthors(authors []string) {
+	p := cstrings(authors)
+	defer C.free(p)
+	C.gtk_about_dialog_set_authors(v.native(), (**C.gchar)(p))
+}
+
 // GetComments is a wrapper around gtk_about_dialog_get_comments().
 func (v *AboutDialog) GetComments() string {
 	c := C.gtk_about_dialog_get_comments(v.native())

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -867,6 +867,19 @@ func (v *AboutDialog) SetAuthors(authors []string) {
 	C.gtk_about_dialog_set_authors(v.native(), (**C.gchar)(p))
 }
 
+// GetArtists is a wrapper around gtk_about_dialog_get_artists().
+func (v *AboutDialog) GetArtists() []string {
+	p := C.gtk_about_dialog_get_artists(v.native())
+	return gogchars(p)
+}
+
+// SetArtists is a wrapper around gtk_about_dialog_set_artists().
+func (v *AboutDialog) SetArtists(artists []string) {
+	p := cstrings(artists)
+	defer C.free(p)
+	C.gtk_about_dialog_set_artists(v.native(), (**C.gchar)(p))
+}
+
 // GetComments is a wrapper around gtk_about_dialog_get_comments().
 func (v *AboutDialog) GetComments() string {
 	c := C.gtk_about_dialog_get_comments(v.native())


### PR DESCRIPTION
Adds support for conversion from GTK **gchar arrays to Go []string slices and vice versa to support assorted GtkAboutDialog functions.
